### PR TITLE
feat(middleware): Added delay and failureRate middleware, and combine…

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,26 @@ npm install yet-another-fetch-mock --save-dev
 ### Setup 
 
 ```javascript
+const loggingMiddleware: Middleware = (request, response) => {
+  console.log('response', response);
+  return response;
+}
+
+
 const mock = FetchMock.configure({
-  enableFallback: true,
-  middleware: (requestArgs, response) => {
-    console.log('response', response);
-    return response;
-  }
+  enableFallback: true, // default: true
+  middleware: loggingMiddleware // default: (req, resp) => resp
+});
+
+
+const delayedErrorMock = FetchMock.configure({
+  middleware: MiddlewareUtils.combine(
+    MiddlewareUtils.delayMiddleware(200),
+    MiddlewareUtils.failurerateMiddleware(0.2)
+  )
 });
 ```
+
 
 ### Examples
 ```typescript

--- a/src/middleware-utils.ts
+++ b/src/middleware-utils.ts
@@ -1,0 +1,42 @@
+import { HandlerArgument, Middleware, ResponseData } from './types';
+
+const defaultFailure: ResponseData = {
+  status: 500,
+  statusText: 'Internal server error'
+};
+
+export default class MiddlewareUtils {
+  static combine(...middlewares: Middleware[]): Middleware {
+    return (request: HandlerArgument, response: ResponseData) => {
+      return middlewares.reduce(
+        (currentResponse, middleware) => currentResponse.then(resp => middleware(request, resp)),
+        Promise.resolve(response)
+      );
+    };
+  }
+
+  static delayMiddleware(delayMs: number): Middleware {
+    return (request: HandlerArgument, response: ResponseData) => {
+      return new Promise<ResponseData>(resolve => {
+        setTimeout(() => resolve(response), delayMs);
+      });
+    };
+  }
+
+  static failurerateMiddleware(
+    probabilityOfFailure: number,
+    failure: ResponseData = defaultFailure
+  ): Middleware {
+    return (request: HandlerArgument, response: ResponseData) => {
+      return new Promise<ResponseData>(resolve => {
+        const rnd = Math.random();
+
+        if (rnd < probabilityOfFailure) {
+          resolve(failure);
+        } else {
+          resolve(response);
+        }
+      });
+    };
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,10 +49,12 @@ export interface Route {
   matcher: RouteMatcher;
   handler: MockHandlerFunction;
 }
+
+export type Middleware = (
+  request: HandlerArgument,
+  response: ResponseData
+) => ResponseData | Promise<ResponseData>;
 export interface Configuration {
   enableFallback: boolean;
-  middleware: (
-    request: HandlerArgument,
-    response: ResponseData
-  ) => ResponseData | Promise<ResponseData>;
+  middleware: Middleware;
 }

--- a/test/math-mock.ts
+++ b/test/math-mock.ts
@@ -1,0 +1,16 @@
+export default class MathMock {
+  private static oldMath = global.Math;
+  private static newMath = Object.create(MathMock.oldMath);
+
+  static setup() {
+    global.Math = MathMock.newMath;
+  }
+
+  static teardown() {
+    global.Math = MathMock.oldMath;
+  }
+
+  static fixRandom(num: number) {
+    MathMock.newMath.random = () => num;
+  }
+}

--- a/test/yet-another-fetch-mock.test.ts
+++ b/test/yet-another-fetch-mock.test.ts
@@ -2,8 +2,10 @@ import 'isomorphic-fetch';
 import MatcherUtils from './../src/matcher-utils';
 import ResponseUtils from './../src/response-utils';
 import FetchMock from '../src/yet-another-fetch-mock';
-import { HandlerArgument, RequestUrl } from '../src/types';
+import { HandlerArgument, RequestUrl, ResponseData } from '../src/types';
 import { findBody, findPathParams } from '../src/internal-utils';
+import MiddlewareUtils from '../src/middleware-utils';
+import MathMock from './math-mock';
 
 function fetchToJson(url: string, options?: RequestInit) {
   return fetch(url, options).then(resp => resp.json());
@@ -236,6 +238,78 @@ describe('FetchMock', () => {
 
     fetchToJson('/lowercase', { method: 'post' }).then(json => {
       expect(json.key).toBe('BIG-CASE');
+      done();
+    });
+  });
+});
+
+describe('middleware-utils', () => {
+  beforeAll(MathMock.setup);
+  afterAll(MathMock.teardown);
+
+  it('should combine middlewares', done => {
+    MathMock.fixRandom(0.2);
+    const delay = jest.fn(MiddlewareUtils.delayMiddleware(100));
+    const failure = jest.fn(MiddlewareUtils.failurerateMiddleware(0.3, { status: 1337 }));
+    const startTime = new Date().getTime();
+
+    const combined = MiddlewareUtils.combine(delay, failure);
+    const result = combined({} as HandlerArgument, 'data' as ResponseData);
+
+    (result as Promise<ResponseData>).then(res => {
+      const endTime = new Date().getTime();
+      expect(endTime - startTime).toBeGreaterThanOrEqual(100);
+
+      expect(res.status).toBe(1337);
+      expect(delay).toHaveBeenCalledTimes(1);
+      expect(failure).toHaveBeenCalledTimes(1);
+      done();
+    });
+  });
+
+  it('should delay the response', done => {
+    const delay = MiddlewareUtils.delayMiddleware(100);
+    const result = delay({} as HandlerArgument, 'delayed' as ResponseData);
+    const startTime = new Date().getTime();
+
+    (result as Promise<String>).then(res => {
+      const endTime = new Date().getTime();
+
+      expect(endTime - startTime).toBeGreaterThanOrEqual(100);
+      expect(res).toBe('delayed');
+      done();
+    });
+  });
+
+  it('should have a random failure rate', done => {
+    MathMock.fixRandom(0.2);
+    const delay = MiddlewareUtils.failurerateMiddleware(0.3);
+    const result = delay({} as HandlerArgument, 'normal-response' as ResponseData);
+
+    (result as Promise<ResponseData>).then(res => {
+      expect(res.status).toBe(500);
+      done();
+    });
+  });
+
+  it('should have a random failure rate2', done => {
+    MathMock.fixRandom(0.4);
+    const delay = MiddlewareUtils.failurerateMiddleware(0.3);
+    const result = delay({} as HandlerArgument, 'normal-response' as ResponseData);
+
+    (result as Promise<String>).then(res => {
+      expect(res).toBe('normal-response');
+      done();
+    });
+  });
+
+  it('should support custom error response', done => {
+    MathMock.fixRandom(0.2);
+    const delay = MiddlewareUtils.failurerateMiddleware(0.3, { status: 1337 });
+    const result = delay({} as HandlerArgument, 'normal-response' as ResponseData);
+
+    (result as Promise<ResponseData>).then(res => {
+      expect(res.status).toBe(1337);
       done();
     });
   });


### PR DESCRIPTION
… of these

In order to facilitate easier combination of middleware we've added a `combine` method for
middlewares. `delay` and `failureRate` middlewares are added in as well, since these are most likely
something most people will use.

#2